### PR TITLE
Disabled enableAcceleratedNetworking

### DIFF
--- a/contrib/CGF-Quickstart-HA-2NIC-AZ-ELB-ILB-STD/azuredeploy.json
+++ b/contrib/CGF-Quickstart-HA-2NIC-AZ-ELB-ILB-STD/azuredeploy.json
@@ -591,7 +591,7 @@
       ],
       "properties": {
         "enableIPForwarding": true,
-		"enableAcceleratedNetworking": true,
+	"enableAcceleratedNetworking": false,
         "ipConfigurations": [
           {
             "name": "external",
@@ -625,7 +625,7 @@
       ],
       "properties": {
         "enableIPForwarding": true,
-		"enableAcceleratedNetworking": true,
+	"enableAcceleratedNetworking": false,
         "ipConfigurations": [
           {
             "name": "ipconfig1",
@@ -657,7 +657,7 @@
       ],
       "properties": {
         "enableIPForwarding": true,
-		"enableAcceleratedNetworking": true,
+	"enableAcceleratedNetworking": false,
         "ipConfigurations": [
           {
             "name": "external",
@@ -691,7 +691,7 @@
       ],
       "properties": {
         "enableIPForwarding": true,
-		"enableAcceleratedNetworking": true,
+	"enableAcceleratedNetworking": false,
         "ipConfigurations": [
           {
             "name": "internal",


### PR DESCRIPTION
Set enableAcceleratedNetworking to false, because Barracuda isn't reachable by public IP during the first start if acc networking is enabled.

It seems, that there is some further work in the cfgCustomData necessary to support this out of the box.

Current workaround: create additional NICs and replace them after finalizing initial configuration.